### PR TITLE
better error message if no runtime environment is avaiable

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -31,7 +31,7 @@ module ExecJS
 
 
     def self.best_available
-      runtimes.find(&:available?)
+      runtimes.find(&:available?) or raise(ExecJS::RuntimeError, 'Could not find any JavaScript runtime!')
     end
 
     def self.runtimes


### PR DESCRIPTION
```
>> require 'execjs' #=> true
>> ExecJS.eval '123'
NoMethodError: private method `eval' called for nil:NilClass
    from /home/jan/.rvm/gems/ruby-1.9.2-p180/gems/execjs-0.1.0/lib/execjs.rb:18:in `eval'
    from (irb):2
    from /home/jan/.rvm/rubies/ruby-1.9.2-p180/bin/irb:16:in `<main>'
```
