### PR TITLE
Fix ExternalRuntime.which to behave as expected.

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -117,9 +117,10 @@ module ExecJS
           result = if ExecJS.windows?
             `#{ExecJS.root}/support/which.bat #{name}`
           else
-            `which #{name} 2>&1`
+            `which #{name} 2>/dev/null`
           end
-          result.strip.split("\n").first
+					# If the string is empty then the command is not in the $PATH.
+					!result.empty?
         end
       end
 


### PR DESCRIPTION
In current master, the which command returns whichever command comes first in the array regardless of it's presense in the path. This happens because Array#find does not return the value of the first truthy block but the value of the array member which yielded it. Because the result of a failed `which` command returns a text error, this string causes result to evaluate as true, thus making the block truthy in the wrong situation.

Additionally, the standard *nix `which` command returns the full absolute path of a command whereas the version here returns the name of the first command present in the path or `nil`. Perhaps the correct solution is to modify the mothod so it does indeed return the absolute path. If that is the desired behavior I will implement it and then update the pull request.
