### PR TITLE
add .js extension to tempfile (improves Windows compatibility)

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -26,7 +26,7 @@ module ExecJS
 
       protected
         def compile_to_tempfile(source)
-          tempfile = Tempfile.open("execjs")
+          tempfile = Tempfile.open(["execjs",".js"])
           tempfile.write compile(source)
           tempfile.close
           yield tempfile


### PR DESCRIPTION
On Windows7, I was getting the following complaints:

```
ExecJS::RuntimeError (Microsoft (R) Windows Script Host Version 5.8
Copyright (C) Microsoft Corporation. All rights reserved.
Input Error: There is no file extension in "C:\Users\swaits\AppData\Local\Temp\execjs20110427-6772-1dnexso".
```

This is easily resolved by adding a ".js" extension to the tempfile. Luckily, Tempfile.open() already supports this by simply passing it an array, instead of a single String.
