### PR TITLE
Fix external runtime detection under zsh and other shells.

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -123,7 +123,7 @@ module ExecJS
           result = if ExecJS.windows?
             `#{ExecJS.root}/support/which.bat #{name}`
           else
-            `which #{name} 2>/dev/null`
+            `command -v #{name} 2>/dev/null`
           end
 
           if path = result.strip.split("\n").first


### PR DESCRIPTION
The 'which' builtin command in zsh and tcsh behave differently from
(ba)sh, giving an output of 'xxx not found' if a command can't be
found.

'command -v' is the POSIX-compliant way to find out the full path for
a given command, and should work under all shells.
