### PR TITLE
Fix 'which' on Solaris.

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -126,7 +126,7 @@ module ExecJS
             `command -v #{name} 2>/dev/null`
           end
 
-          if path = result.strip.split("\n").first
+          if path = result.strip.split("\n").first and File.exist?(path)
             return args ? "#{path} #{args}" : path
           end
         end


### PR DESCRIPTION
/usr/bin/which is a bit funky on Solaris.  'which foo' will output something
along the lines of "no foo in /opt/ree/bin /usr/bin /usr/sbin /usr/ccs/bin"
to stdout, then exits with a successful status code.  Try harder to verify
which's output.
