### PR TITLE
missing support file

### DIFF
--- a/execjs.gemspec
+++ b/execjs.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
     "lib/execjs/ruby_rhino_runtime.rb",
     "lib/execjs/runtimes.rb",
     "lib/execjs/support/basic_runner.js",
+    "lib/execjs/support/jsc_runner.js",
     "lib/execjs/support/jscript_runner.js",
     "lib/execjs/support/json2.js",
     "lib/execjs/support/node_runner.js",


### PR DESCRIPTION
When i try this i my to run this:

require "execjs"
puts ExecJS.eval "'red yellow blue'.split(' ')"

i got:

No such file or directory - /Users/marlon/.rvm/gems/ruby-1.9.2-head@test/gems/execjs-1.2.3/lib/execjs/support/jsc_runner.js
