### PR TITLE
Paths with spaces in Windows

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -143,7 +143,7 @@ module ExecJS
         Array(command).each do |name|
           name, args = name.split(/\s+/, 2)
           result = if ExecJS.windows?
-            `#{ExecJS.root}/support/which.bat #{name}`
+            `"#{ExecJS.root}/support/which.bat" #{name}`
           else
             `command -v #{name} 2>/dev/null`
           end


### PR DESCRIPTION
I know...paths with spaces are evil...but with pik on windows the path of ruby is something like "C:\Documents and Settings\user\.pik\rubies\ruby-1.9.2-p290-i386-mingw32".
This fix my case on WindowsXP.
