### PR TITLE
Added ability to get results back from asynchronous javascript code.

### DIFF
--- a/lib/execjs/johnson_runtime.rb
+++ b/lib/execjs/johnson_runtime.rb
@@ -87,6 +87,8 @@ module ExecJS
     def name
       "Johnson (SpiderMonkey)"
     end
+    
+    def supports_async?; false; end
 
     def exec(source)
       context = Context.new
@@ -98,7 +100,7 @@ module ExecJS
       context.eval(source)
     end
 
-    def compile(source)
+    def compile(source, options={})
       Context.new(source)
     end
 

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -23,8 +23,8 @@ module ExecJS
       runtime.eval(source)
     end
 
-    def compile(source)
-      runtime.compile(source)
+    def compile(source, options={})
+      runtime.compile(source, options)
     end
 
     def root

--- a/lib/execjs/mustang_runtime.rb
+++ b/lib/execjs/mustang_runtime.rb
@@ -64,9 +64,11 @@ module ExecJS
       context.eval(source)
     end
 
-    def compile(source)
+    def compile(source, options={})
       Context.new(source)
     end
+    
+    def supports_async?; false; end
 
     def available?
       require "mustang"

--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -103,9 +103,11 @@ module ExecJS
       context.eval(source)
     end
 
-    def compile(source)
+    def compile(source, options={})
       Context.new(source)
     end
+    
+    def supports_async?; false; end
 
     def available?
       require "v8"

--- a/lib/execjs/ruby_rhino_runtime.rb
+++ b/lib/execjs/ruby_rhino_runtime.rb
@@ -87,9 +87,11 @@ module ExecJS
       context.eval(source)
     end
 
-    def compile(source)
+    def compile(source, options={})
       Context.new(source)
     end
+    
+    def supports_async?; false; end
 
     def available?
       require "rhino"

--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -16,9 +16,10 @@ module ExecJS
     Mustang = MustangRuntime.new
 
     Node = ExternalRuntime.new(
-      :name        => "Node.js (V8)",
-      :command     => ["nodejs", "node"],
-      :runner_path => ExecJS.root + "/support/node_runner.js"
+      :name              => "Node.js (V8)",
+      :command           => ["nodejs", "node"],
+      :runner_path       => ExecJS.root + "/support/node_runner.js",
+      :async_runner_path => ExecJS.root + "/support/node_runner_async.js"
     )
 
     JavaScriptCore = ExternalRuntime.new(

--- a/lib/execjs/support/node_runner_async.js
+++ b/lib/execjs/support/node_runner_async.js
@@ -1,0 +1,21 @@
+(function(program, execJS, module, exports, require) { execJS(program) })(function(callback) { #{source}
+}, function(program) {
+  var output, print = function(string) {
+    process.stdout.write('' + string);
+  };
+  try {
+    program(function(result){
+      if (typeof result == 'undefined' && result !== null) {
+        print('["ok"]');
+      } else {
+        try {
+          print(JSON.stringify(['ok', result]));
+        } catch (err) {
+          print('["err"]');
+        }
+      } 
+    });
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err]));
+  }
+});

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -33,6 +33,13 @@ class TestExecJS < Test::Unit::TestCase
     assert_equal "bar", context.exec("return foo()")
     assert_equal "bar", context.eval("foo()")
   end
+  
+  def test_compile_async
+    if ExecJS.runtime.supports_async?
+      context = ExecJS.compile("foo = function() { callback('bar') }", :async => true)
+      assert_equal "bar", context.eval("foo()")
+    end
+  end
 
   def test_context_call
     context = ExecJS.compile("id = function(v) { return v; }")


### PR DESCRIPTION
Added ability to get results back from asynchronous javascript code.  Currently works with the node runtime only.

The use case for this was running something like jsdom, like this:

``` javascript
  jsdom.jQueryify(window, "http://code.jquery.com/jquery-1.4.2.js", function() {
    window.jQuery('body').append("<div class='testing'>Hello World, It works!</div>");
  });
```

And I wanted the result to be the document body, but since this function works asynchronously, there was no way to get it back.

As you can see, I added the node_runner_async script which passes in a callback function to the `program`, and so the user supplied javascript code can invoke the callback to return a result.

So, now this works:

``` ruby
context = ExecJS.compile %{
  var run = function(code){
    var jsdom  = require("jsdom"),
        window = jsdom.jsdom().createWindow();

    jsdom.jQueryify(window, "http://code.jquery.com/jquery-1.4.2.js", function() {
      window.jQuery('body').append("<div class='testing'>Hello World, It works!</div>");
      callback(window.jQuery('body').html());
    });
  }
}, async: true

context.call 'run' #=> "<div class='testing'>Hello World, It works!</div>"
```

All tests pass running `rake test:node`.
