### PR TITLE
Change to look for jsc in PATH so it will be found on most linux machines

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -23,7 +23,7 @@ module ExecJS
 
     JavaScriptCore = ExternalRuntime.new(
       :name        => "JavaScriptCore",
-      :command     => ["jsc", "/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc"],
+      :command     => ["/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Resources/jsc", "jsc"],
       :runner_path => ExecJS.root + "/support/jsc_runner.js"
     )
 


### PR DESCRIPTION
Find jsc when it is in your PATH so it can be used on linux as well as osx.

Recently found myself wanting to use webkit's jsc on linux :)
