### PR TITLE
Ensure that commands and args are properly quoted if they contain spaces or reserved shell characters (on Windows).

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -183,7 +183,10 @@ module ExecJS
       if ExecJS.windows?
         def shell_escape(*args)
           # see http://technet.microsoft.com/en-us/library/cc723564.aspx#XSLTsection123121120120
-          args.map { |arg| arg.gsub(/([&|()<>^ "])/,'^\1') }.join(" ")
+          args.map { |arg|
+            arg = %Q("#{arg.gsub('"','""')}") if arg.match(/[&|()<>^ "]/)
+            arg
+          }.join(" ")
         end
       else
         def shell_escape(*args)


### PR DESCRIPTION
http://technet.microsoft.com/en-us/library/cc723564.aspx states that "all reserved shell characters not in double quotes must be escaped." It also states that "any argument that contains spaces...must be enclosed in double quotes" Furthermore, "if a double-quoted argument itself contains a double quote character, the double quote must be doubled."

The existing code handles reserved shell characters properly, but does not properly handle spaces.  Spaces cannot be escaped by prefixing them with a '^'. The immediate impact is that compiling of .js will not work on Windows when using the default ENV['TEMP'](which contains spaces).

This patch changes the strategy of escaping each reserved shell character individually to quoting the whole argument when a space OR reserved shell character is present.
