### PR TITLE
Fixes #59. Avoid find directories as executables.

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -130,7 +130,8 @@ module ExecJS
           cmd
         else
           path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|
-            File.executable? File.join(p, cmd)
+            full_path = File.join(p, cmd)
+            File.executable?(full_path) && File.file?(full_path)
           }
           path && File.expand_path(cmd, path)
         end


### PR DESCRIPTION
Having a directory named node or nodejs causes problems in unix enviroments because
directories are executables.
