### PR TITLE
Fixes #67. Avoid find directories as executables.

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -126,7 +126,7 @@ module ExecJS
           cmd << ".exe"
         end
 
-        if File.executable? cmd
+        if File.executable?(cmd) && File.file?(cmd)
           cmd
         else
           path = ENV['PATH'].split(File::PATH_SEPARATOR).find { |p|


### PR DESCRIPTION
Having a directory named node or nodejs in the current directory causes problems in unix enviroments because
directories are executables. Related to #59.
