### PR TITLE
Fix invalid MultiJson API detection (closes #82)

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -85,21 +85,19 @@ module ExecJS
           end
         end
 
-        if MultiJson.respond_to?(:load)
+        if MultiJson.respond_to?(:dump)
           def json_decode(obj)
             MultiJson.load(obj)
           end
-        else
-          def json_decode(obj)
-          MultiJson.decode(obj)
-          end
-        end
 
-        if MultiJson.respond_to?(:dump)
           def json_encode(obj)
             MultiJson.dump(obj)
           end
         else
+          def json_decode(obj)
+            MultiJson.decode(obj)
+          end
+
           def json_encode(obj)
             MultiJson.encode(obj)
           end


### PR DESCRIPTION
This commit is a patch for #82.

`#load` is defined in Kernel and inherited in every object, thus Object.respond_to?(:load) will always return true.

MultiJson switched to load/dump from decode/encode. It's safe to use a single check (to verify the presence of the `dump` method) for both encoding and decoding.
