### PR TITLE
Minor change to include more detail for V8 runtime exceptions

### DIFF
--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -29,7 +29,7 @@ module ExecJS
               if e.value["name"] == "SyntaxError"
                 raise RuntimeError, e.message
               else
-                raise ProgramError, e.message
+                raise ProgramError, e.value.to_s
               end
             end
           end


### PR DESCRIPTION
This makes it much easier to see why an error occurred - the value.to_s serializes the JS stacktrace.   The nice thing is the message is still in value, but it also includes details like line number etc...
