### PR TITLE
Allow custom json options to be specified

### DIFF
--- a/lib/execjs.rb
+++ b/lib/execjs.rb
@@ -3,4 +3,5 @@ require "execjs/runtimes"
 
 module ExecJS
   self.runtime ||= Runtimes.autodetect
+  self.json_options = {}
 end

--- a/lib/execjs/json.rb
+++ b/lib/execjs/json.rb
@@ -3,20 +3,20 @@ require "multi_json"
 module ExecJS
   module JSON
     if MultiJson.respond_to?(:dump)
-      def self.decode(obj)
-        MultiJson.load(obj)
+      def self.decode(obj, json_options = ExecJS.json_options)
+        MultiJson.load(obj, json_options)
       end
 
-      def self.encode(obj)
-        MultiJson.dump(obj)
+      def self.encode(obj, json_options = ExecJS.json_options)
+        MultiJson.dump(obj, json_options)
       end
     else
-      def self.decode(obj)
-        MultiJson.decode(obj)
+      def self.decode(obj, json_options = ExecJS.json_options)
+        MultiJson.decode(obj, json_options)
       end
 
-      def self.encode(obj)
-        MultiJson.encode(obj)
+      def self.encode(obj, json_options = ExecJS.json_options)
+        MultiJson.encode(obj, json_options)
       end
     end
   end

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -9,6 +9,7 @@ module ExecJS
 
   class << self
     attr_reader :runtime
+    attr_accessor :json_options
 
     def runtime=(runtime)
       raise RuntimeUnavailable, "#{runtime.name} is unavailable on this system" unless runtime.available?


### PR DESCRIPTION
This allows other libraries to prevent errors like:

nesting of 20 is too deep

https://github.com/elabs/serenade.js/issues/64
