### PR TITLE
[rhino] do not force therubyrhino (>= 2.0.2) into interpreted mode 

### DIFF
--- a/lib/execjs/ruby_rhino_runtime.rb
+++ b/lib/execjs/ruby_rhino_runtime.rb
@@ -74,16 +74,9 @@ module ExecJS
           end
         end
 
-        @@fix_memory_limit = nil
-
         def fix_memory_limit?
-          return @@fix_memory_limit unless @@fix_memory_limit.nil?
-          version = defined?(::Rhino::VERSION) && ::Rhino::VERSION
-          if version && Gem::Version.create(version) >= Gem::Version.create('2.0.2')
-            @@fix_memory_limit = false
-          else
-            @@fix_memory_limit = true
-          end
+          ! Rhino::Context.respond_to?(:default_optimization_level)
+          # added in 2.0.2 which auto-switches optimization level (to -1)
         end
     end
 


### PR DESCRIPTION
Hey, I've just released therubyrhino **2.0.2** which deals with the 64K limit issue itself.
It would be great to get this into an **ExecJS** release since it provides a **~30%** performance increase e.g. when compiling assets on JRuby. 

It might not work for all and might even de-crease performance but only with about a second for every script that fails compiling into a byte-code and thus gets re-tried in (slow) interpreter mode.

These are scripts that have a lot of code in a single scope (e.g. in global) and since each scope gets compiled into a method it is most likely to fail, one such script is _coffee-script.js_ and the de-crease might be observed in tests : 

therubyrhino 2.0.1

```
kares@theborg:~/workspace/github/execjs$ rake test:rubyrhino
Run options: 

# Running tests:

.................

Finished tests in 3.825000s, 4.4444 tests/s, 15.9477 assertions/s.

```

therubyrhino 2.0.2

```
kares@theborg:~/workspace/github/execjs$ rake test:rubyrhino
Run options: 

# Running tests:

...[INFO] Rhino byte-code generation failed forcing org.mozilla.javascript.Context@5fadce into interpreted mode
..............

Finished tests in 5.145000s, 3.3042 tests/s, 11.8562 assertions/s.

```

But this is not really an issue since when compiling multiple-scripts a second wasted on a script or two might be re-gained on others (and if it's a single huge script it will only add-up ~1s once). The latest gem also allows to specify optimization level via a system property thus strict (interpreter) Rhino users that do not trust Java byte-code will still be HAPPY :) !

Now let's see the gains of this addition with pre-compiling assets Rails 3.2.9 on JRuby with :
_environments/production.rb_

``` ruby
  config.assets.compress = true
  config.assets.digest = true
```

_application.js_ contains the "usual" jQuery files :

```
//= require jquery
//= require jquery
//= require jquery_ujs
//= require jquery.ui.all
//= require jquery.mobile-1.1.1
```

BEFORE (therubyrhino 2.0.1) :

```
kares@theborg:~/workspace/github/jruby-rack/examples/rails32$ time rake assets:precompile:all RAILS_ENV=production

real    2m55.666s
user    2m54.811s
sys 0m2.164s
```

AFTER (therubyrhino 2.0.2) : 

```
kares@theborg:~/workspace/github/jruby-rack/examples/rails32$ time rake assets:precompile:all RAILS_ENV=production

real    2m0.239s
user    2m1.424s
sys 0m2.136s
```

We seem to have saved 1 minute out of 3 which should be noticeable by all JRuby users ...
