### PR TITLE
add license information to the gemspec

### DIFF
--- a/execjs.gemspec
+++ b/execjs.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
 
   s.authors = ["Sam Stephenson", "Josh Peek"]
   s.email   = ["sstephenson@gmail.com", "josh@joshpeek.com"]
+  s.license = "MIT"
 end


### PR DESCRIPTION
This way you can use rubygems.org API to know this information
