### PR TITLE
Direct V8 support via it's d8 runner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ExecJS supports these runtimes:
   embedded within Ruby
 * [therubyrhino](https://github.com/cowboyd/therubyrhino) - Mozilla
   Rhino embedded within JRuby
+* [Google V8](http://code.google.com/p/v8/)
 * [Node.js](http://nodejs.org/)
 * Apple JavaScriptCore - Included with Mac OS X
 * [Microsoft Windows Script Host](http://msdn.microsoft.com/en-us/library/9bbdkx3k.aspx) (JScript)

--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -31,6 +31,13 @@ module ExecJS
       :runner_path => ExecJS.root + "/support/jsc_runner.js"
     )
 
+    V8 = ExternalRuntime.new(
+      :name        => "V8",
+      :command     => "d8",
+      :runner_path => ExecJS.root + "/support/d8_runner.js",
+      :encoding    => 'UTF-8'
+    )
+
     SpiderMonkey = Spidermonkey = ExternalRuntime.new(
       :name        => "SpiderMonkey",
       :command     => "js",
@@ -80,6 +87,7 @@ module ExecJS
         RubyRhino,
         Johnson,
         Mustang,
+        V8,
         Node,
         JavaScriptCore,
         SpiderMonkey,

--- a/lib/execjs/support/d8_runner.js
+++ b/lib/execjs/support/d8_runner.js
@@ -1,0 +1,19 @@
+(function(program, execJS) { execJS(program) })(function() { #{source}
+}, function(program) {
+  #{json2_source}
+  var output;
+  try {
+    result = program();
+    if (typeof result == 'undefined' && result !== null) {
+      print('["ok"]');
+    } else {
+      try {
+        print(JSON.stringify(['ok', result]));
+      } catch (err) {
+        print('["err"]');
+      }
+    }
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err]));
+  }
+});


### PR DESCRIPTION
On FreeBSD, [d8](http://www.freshports.org/lang/v8) is kinda faster than node. Plus it does not fail in strange ways on 32bits architectures.

I stole the javascript runner from the SpiderMonkey one.
