### PR TITLE
Would you consider taking this change?

### DIFF
--- a/lib/execjs/disabled_runtime.rb
+++ b/lib/execjs/disabled_runtime.rb
@@ -6,11 +6,11 @@ module ExecJS
       "Disabled"
     end
 
-    def exec(source)
+    def exec(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
-    def eval(source)
+    def eval(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
@@ -27,3 +27,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/johnson_runtime.rb
+++ b/lib/execjs/johnson_runtime.rb
@@ -104,3 +104,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -15,12 +15,12 @@ module ExecJS
       @runtime = runtime
     end
 
-    def exec(source)
-      runtime.exec(source)
+    def exec(source, options = {})
+      runtime.exec(source, options)
     end
 
-    def eval(source)
-      runtime.eval(source)
+    def eval(source, options = {})
+      runtime.eval(source, options)
     end
 
     def compile(source)
@@ -36,3 +36,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/runtime.rb
+++ b/lib/execjs/runtime.rb
@@ -30,14 +30,14 @@ module ExecJS
       self.class::Context
     end
 
-    def exec(source)
+    def exec(source, options = {})
       context = context_class.new(self)
-      context.exec(source)
+      context.exec(source, options)
     end
 
-    def eval(source)
+    def eval(source, options = {})
       context = context_class.new(self)
-      context.eval(source)
+      context.eval(source, options)
     end
 
     def compile(source)
@@ -53,3 +53,4 @@ module ExecJS
     end
   end
 end
+


### PR DESCRIPTION
Update to ExternalRuntime to use Kernel.spawn version of IO.popen to merge stderr and stdout and enable timeouts

This fix changes exec_runtime to take an options hash that allows the caller to specify a :timeout option. This will impose a timeout on an exec or eval call. The with_timeout helper method imposes this timeout by running the external command on a separate thread if a non-zero and non-nil. Using the Kernel.spawn version of the IO.popen method means that only a single child process needs to be spawned to handle merging of stderr and stdout: this allows exec_runtime to properly clean up the child process without leaving any orphans hanging around. The exec and eval methods on Module and Runtime have been updated to take the new options hash. Note that this change does not implement timeouts for other runtimes. This will follow as I get to them.

REFERENCES

http://unethicalblogger.com/2011/11/12/popen-can-suck-it.html
