### PR TITLE
Update to ExternalRuntime to use Kernel.spawn version of IO.popen to merge stderr and stdout and enable timeouts

### DIFF
--- a/lib/execjs/disabled_runtime.rb
+++ b/lib/execjs/disabled_runtime.rb
@@ -6,11 +6,11 @@ module ExecJS
       "Disabled"
     end
 
-    def exec(source)
+    def exec(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
-    def eval(source)
+    def eval(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
@@ -27,3 +27,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -25,7 +25,7 @@ module ExecJS
         source = "#{@source}\n#{source}" if @source
 
         compile_to_tempfile(source) do |file|
-          extract_result(@runtime.send(:exec_runtime, file.path))
+          extract_result(@runtime.send(:exec_runtime, file.path, options))
         end
       end
 
@@ -134,9 +134,12 @@ module ExecJS
         @runner_source ||= IO.read(@runner_path)
       end
 
-      def exec_runtime(filename)
-        output = sh("#{shell_escape(*(binary.split(' ') << filename))} 2>&1")
-        if $?.success?
+      def exec_runtime(filename, options)
+        command =  binary.split(' ') << filename << {:err => [:child, :out]}
+        result = sh(command, options)
+        process_status = result[:process_status]
+        output = result[:output]
+        if process_status.success?
           output
         else
           raise RuntimeError, output
@@ -165,27 +168,38 @@ module ExecJS
         end
       end
 
-      if "".respond_to?(:force_encoding)
-        def sh(command)
-          output, options = nil, {}
-          options[:external_encoding] = @encoding if @encoding
-          options[:internal_encoding] = ::Encoding.default_internal || 'UTF-8'
-          IO.popen(command, options) { |f| output = f.read }
-          output
+      @@supports_force_encoding = ''.respond_to?(:force_encoding)
+
+      def sh(command, options)
+        pid, process_status, output, popen_options = nil, nil, nil, {}
+
+        if @@supports_force_encoding
+          popen_options[:external_encoding] = @encoding if @encoding
+          popen_options[:internal_encoding] = ::Encoding.default_internal || 'UTF-8'
         end
-      else
-        require "iconv"
 
-        def sh(command)
-          output = nil
-          IO.popen(command) { |f| output = f.read }
-
-          if @encoding
-            Iconv.new('UTF-8', @encoding).iconv(output)
-          else
-            output
+        begin
+          with_timeout(options[:timeout]) do
+            IO.popen(command, popen_options) do |f|
+              pid = f.pid
+              output = f.read
+            end
+            process_status = $?
           end
+        rescue Timeout::Error
+          if !pid.nil?
+            Process.kill 'KILL', pid
+            Process.wait pid
+          end
+          raise
         end
+
+        if not @@supports_force_encoding
+          require 'iconv'
+          output = Iconv.new('UTF-8', @encoding).iconv(output) if @encoding
+        end
+
+        {:process_status => process_status, :output => output}
       end
 
       if ExecJS.windows?
@@ -201,5 +215,31 @@ module ExecJS
           Shellwords.join(args)
         end
       end
+
+      def with_timeout(sec)
+        return yield if sec.nil? or sec.zero?
+
+        result, timed_out = nil, true
+
+        worker_thread = Thread.new do
+          result = yield
+          timed_out = false
+        end
+
+        timeout_thread = Thread.new do
+          sleep sec
+          if worker_thread.alive?
+            worker_thread.kill
+            sleep 0
+            worker_thread.raise
+          end
+        end
+
+        worker_thread.join
+        timeout_thread.kill
+        raise Timeout::Error if timed_out
+        result
+      end
   end
 end
+

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -15,12 +15,12 @@ module ExecJS
       @runtime = runtime
     end
 
-    def exec(source)
-      runtime.exec(source)
+    def exec(source, options = {})
+      runtime.exec(source, options)
     end
 
-    def eval(source)
-      runtime.eval(source)
+    def eval(source, options = {})
+      runtime.eval(source, options)
     end
 
     def compile(source)
@@ -36,3 +36,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/runtime.rb
+++ b/lib/execjs/runtime.rb
@@ -30,14 +30,14 @@ module ExecJS
       self.class::Context
     end
 
-    def exec(source)
+    def exec(source, options = {})
       context = context_class.new(self)
-      context.exec(source)
+      context.exec(source, options)
     end
 
-    def eval(source)
+    def eval(source, options = {})
       context = context_class.new(self)
-      context.eval(source)
+      context.eval(source, options)
     end
 
     def compile(source)
@@ -53,3 +53,4 @@ module ExecJS
     end
   end
 end
+


### PR DESCRIPTION
This fix changes exec_runtime to take an options hash that allows the caller to specify a :timeout option. This will impose a timeout on an exec or eval call. The with_timeout helper method imposes this timeout by running the external command on a separate thread if a non-zero and non-nil. Using the Kernel.spawn version of the IO.popen method means that only a single child process needs to be spawned to handle merging of stderr and stdout: this allows exec_runtime to properly clean up the child process without leaving any orphans hanging around. The exec and eval methods on Module and Runtime have been updated to take the new options hash. Note that this change does not implement timeouts for other runtimes. This will follow as I get to them.

REFERENCES

http://unethicalblogger.com/2011/11/12/popen-can-suck-it.html
