### PR TITLE
Incorporates timeout mechanism into ExternalRuntime for Ruby 1.9 and later

### DIFF
--- a/lib/execjs/disabled_runtime.rb
+++ b/lib/execjs/disabled_runtime.rb
@@ -6,11 +6,11 @@ module ExecJS
       "Disabled"
     end
 
-    def exec(source)
+    def exec(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
-    def eval(source)
+    def eval(source, options = {})
       raise Error, "ExecJS disabled"
     end
 
@@ -27,3 +27,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -15,12 +15,12 @@ module ExecJS
       @runtime = runtime
     end
 
-    def exec(source)
-      runtime.exec(source)
+    def exec(source, options = {})
+      runtime.exec(source, options)
     end
 
-    def eval(source)
-      runtime.eval(source)
+    def eval(source, options = {})
+      runtime.eval(source, options)
     end
 
     def compile(source)
@@ -36,3 +36,4 @@ module ExecJS
     end
   end
 end
+

--- a/lib/execjs/runtime.rb
+++ b/lib/execjs/runtime.rb
@@ -30,14 +30,14 @@ module ExecJS
       self.class::Context
     end
 
-    def exec(source)
+    def exec(source, options = {})
       context = context_class.new(self)
-      context.exec(source)
+      context.exec(source, options)
     end
 
-    def eval(source)
+    def eval(source, options = {})
       context = context_class.new(self)
-      context.eval(source)
+      context.eval(source, options)
     end
 
     def compile(source)
@@ -53,3 +53,4 @@ module ExecJS
     end
   end
 end
+


### PR DESCRIPTION
Uses Ruby 1.9 IO.popen options that result in Kernel.spawn under the covers. This enables a simple timeout mechanism to be implemented. Falls back to current IO.popen for pre-Ruby 1.9.
