### PR TITLE
Adding '#encoding: UTF-8' comment to fix 'incompatible character encoding: /[\u0080-\uffff]/' error

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require "shellwords"
 require "tempfile"
 require "execjs/runtime"


### PR DESCRIPTION
I kept experiencing the following error using execjs with JRuby

SyntaxError - (RegexpError) incompatible character encoding: /[\u0080-\uffff]/:
  vendor/bundle/jruby/1.9/gems/execjs-1.4.0/lib/execjs/external_runtime.rb:74:in `encode_unicode_codepoints'

The error goes away if the # encoding: UTF-8 comment is added at the top of external_runtime.rb.
