### PR TITLE
Use JSON.generate to properly quote JS string

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -16,7 +16,7 @@ module ExecJS
         source = encode(source)
 
         if /\S/ =~ source
-          exec("return eval(#{::JSON.dump("(#{source})")})")
+          exec("return eval(#{::JSON.generate("(#{source})", :quirks_mode => true)})")
         end
       end
 


### PR DESCRIPTION
`JSON.dump("string")` fails as JSON can't have a string at first level (it should be an object or an array). `JSON.generate` in it's turn allows to pass [options](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/json/rdoc/JSON.html#method-i-generate), so we can enable quirks mode to use JSON as a string escaper.

Notice that although `JSON#generate` has no info about quirks mode, it uses [Generator::State](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/json/rdoc/JSON/Ext/Generator/State.html#method-c-new) which has detailed info about possible options.

Resolves #129
