### PR TITLE
Update runtimes.rb

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -42,7 +42,7 @@ module ExecJS
       :name        => "JScript",
       :command     => "cscript //E:jscript //Nologo //U",
       :runner_path => ExecJS.root + "/support/jscript_runner.js",
-      :encoding    => 'UTF-16LE' # CScript with //U returns UTF-16LE
+      :encoding    => 'UTF-8' # Turbolinks on Windows needs UTF-8 to function properly / CScript with //U returns UTF-16LE
     )
 
 


### PR DESCRIPTION
Line 45 was changed, needed encoding of UTF-8 for Windows based machines. Generating a basic scaffold will give errors with UTF-16LE.
