### PR TITLE
add the line number for errors in V8 and NodeJS

### DIFF
--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -28,11 +28,7 @@ module ExecJS
             begin
               unbox @v8_context.eval("(#{source})")
             rescue ::V8::JSError => e
-              if e.value["name"] == "SyntaxError"
-                raise RuntimeError, e.value.to_s
-              else
-                raise ProgramError, e.value.to_s
-              end
+              raise wrap_error(e)
             end
           end
         end
@@ -43,11 +39,7 @@ module ExecJS
           begin
             unbox @v8_context.eval(properties).call(*args)
           rescue ::V8::JSError => e
-            if e.value["name"] == "SyntaxError"
-              raise RuntimeError, e.value.to_s
-            else
-              raise ProgramError, e.value.to_s
-            end
+            raise wrap_error(e)
           end
         end
       end
@@ -87,6 +79,15 @@ module ExecJS
             raise exception
           else
             result
+          end
+        end
+
+        def wrap_error(e)
+          msg = "#{e.value['name']}: #{e}" # only V8::Error#to_s includes the line number
+          if e.value['name'] == "SyntaxError"
+            RuntimeError.new(msg)
+          else
+            ProgramError.new(msg)
           end
         end
     end

--- a/lib/execjs/support/node_runner.js
+++ b/lib/execjs/support/node_runner.js
@@ -15,6 +15,6 @@
       }
     }
   } catch (err) {
-    print(JSON.stringify(['err', '' + err]));
+    print(JSON.stringify(['err', '' + err.stack]));
   }
 });

--- a/test/test_execjs.rb
+++ b/test/test_execjs.rb
@@ -154,6 +154,17 @@ class TestExecJS < Test::Unit::TestCase
     end
   end
 
+  def test_syntax_error_with_line_numbers
+    return unless %w(RubyRacer Node).include? ENV["EXECJS_RUNTIME"]
+    err = nil
+    begin
+      ExecJS.exec("\n\n)")
+    rescue => e
+      err = e
+    end
+    assert /\b3\b/.match(err.to_s)
+  end
+
   def test_thrown_exception
     assert_raise ExecJS::ProgramError do
       ExecJS.exec("throw 'hello'")


### PR DESCRIPTION
Most ExecJS exceptions does not include the information about where the JavaScript error occurs.

This patch adds line numbers to NodeJS and V8 implementations to ease debugging, although the information includes some garbage like temporary filenames.
