### PR TITLE
Convert Unix paths to Windows format under Cygwin

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -25,7 +25,12 @@ module ExecJS
         source = "#{@source}\n#{source}" if @source
 
         compile_to_tempfile(source) do |file|
-          extract_result(@runtime.send(:exec_runtime, file.path))
+          if ExecJS.cygwin?
+            filepath = `cygpath -m #{file.path}`.rstrip
+          else
+            filepath = file.path
+          end
+          extract_result(@runtime.send(:exec_runtime, filepath))
         end
       end
 

--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -34,5 +34,9 @@ module ExecJS
     def windows?
       @windows ||= RbConfig::CONFIG["host_os"] =~ /mswin|mingw/
     end
+
+    def cygwin?
+      @cygwin ||= RbConfig::CONFIG["host_os"] =~ /cygwin/
+    end
   end
 end


### PR DESCRIPTION
I've encountered the same problem as raised in issue #78, Unix style paths being passed to non-Cygwin binaries such as CScript.exe or node.js which then fail because of this.

This is a tidied up version of the code that they suggested which detects when running under a Cygwin environment and then uses the cygpath binary to convert the Unix style path to the temporary script file to its Windows equivalent.

If you would prefer the path conversion to occur in a different place in the code I'm very happy to adjust as required.