### PR TITLE
Avoid raising an exception if a tempfile could not opened

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -40,7 +40,9 @@ module ExecJS
           tempfile.close
           yield tempfile
         ensure
-          tempfile.close!
+          if tempfile
+            tempfile.close!
+          end
         end
 
         def compile(source)


### PR DESCRIPTION
This causes an unnecessary crash; the semantics of this procedure
suggest it should swallow exceptions, not create them.

This is #113 in code form.  It's not clear to me _why_ this procedure is defined to swallow exceptions rather than close-and-reraise, yet applying this helped me diagnose an issue that had little to do with temp files.
