### PR TITLE
Optimize: Generate compile substitution method

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -43,18 +43,18 @@ module ExecJS
         end
 
         def compile(source)
-          @runtime.send(:runner_source).dup.tap do |output|
-            output.sub!('#{source}') do
-              source
-            end
-            output.sub!('#{encoded_source}') do
-              encoded_source = encode_unicode_codepoints(source)
-              ::JSON.generate("(function(){ #{encoded_source} })()", quirks_mode: true)
-            end
-            output.sub!('#{json2_source}') do
-              IO.read(ExecJS.root + "/support/json2.js")
-            end
+          output = @runtime.send(:runner_source).dup
+          output.sub!('#{source}') do
+            source
           end
+          output.sub!('#{encoded_source}') do
+            encoded_source = encode_unicode_codepoints(source)
+            ::JSON.generate("(function(){ #{encoded_source} })()", quirks_mode: true)
+          end
+          output.sub!('#{json2_source}') do
+            IO.read(ExecJS.root + "/support/json2.js")
+          end
+          output
         end
 
         def extract_result(output)

--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -22,10 +22,11 @@ module ExecJS
       def exec(source, options = {})
         source = encode(source)
         source = "#{@source}\n#{source}" if @source
+        source = @runtime.compile_source(source)
 
-        tmpfile = compile_to_tempfile(source)
+        tmpfile = write_to_tempfile(source)
         begin
-          extract_result(@runtime.send(:exec_runtime, tmpfile.path))
+          extract_result(@runtime.exec_runtime(tmpfile.path))
         ensure
           File.unlink(tmpfile)
         end
@@ -46,32 +47,11 @@ module ExecJS
           tmpfile
         end
 
-        def compile_to_tempfile(source)
+        def write_to_tempfile(contents)
           tmpfile = create_tempfile(['execjs', 'js'])
-          begin
-            tmpfile.write compile(source)
-            tmpfile.close
-            tmpfile
-          rescue => e
-            tmpfile.close unless tmpfile.closed?
-            File.unlink(tmpfile)
-            raise e
-          end
-        end
-
-        def compile(source)
-          output = @runtime.send(:runner_source).dup
-          output.sub!('#{source}') do
-            source
-          end
-          output.sub!('#{encoded_source}') do
-            encoded_source = encode_unicode_codepoints(source)
-            ::JSON.generate("(function(){ #{encoded_source} })()", quirks_mode: true)
-          end
-          output.sub!('#{json2_source}') do
-            IO.read(ExecJS.root + "/support/json2.js")
-          end
-          output
+          tmpfile.write(contents)
+          tmpfile.close
+          tmpfile
         end
 
         def extract_result(output)
@@ -82,12 +62,6 @@ module ExecJS
             raise RuntimeError, value
           else
             raise ProgramError, value
-          end
-        end
-
-        def encode_unicode_codepoints(str)
-          str.gsub(/[\u0080-\uffff]/) do |ch|
-            "\\u%04x" % ch.codepoints.to_a
           end
         end
     end
@@ -101,6 +75,10 @@ module ExecJS
       @encoding    = options[:encoding]
       @deprecated  = !!options[:deprecated]
       @binary      = nil
+
+      if @runner_path
+        instance_eval generate_compile_method(@runner_path)
+      end
     end
 
     def available?
@@ -134,8 +112,29 @@ module ExecJS
       end
 
     protected
-      def runner_source
-        @runner_source ||= IO.read(@runner_path)
+      def generate_compile_method(path)
+        <<-RUBY
+        def compile_source(source)
+          <<-RUNNER
+          #{IO.read(path)}
+          RUNNER
+        end
+        RUBY
+      end
+
+      def json2_source
+        @json2_source ||= IO.read(ExecJS.root + "/support/json2.js")
+      end
+
+      def encode_source(source)
+        encoded_source = encode_unicode_codepoints(source)
+        ::JSON.generate("(function(){ #{encoded_source} })()", quirks_mode: true)
+      end
+
+      def encode_unicode_codepoints(str)
+        str.gsub(/[\u0080-\uffff]/) do |ch|
+          "\\u%04x" % ch.codepoints.to_a
+        end
       end
 
       def exec_runtime(filename)
@@ -146,6 +145,8 @@ module ExecJS
           raise RuntimeError, output
         end
       end
+      # Internally exposed for Context.
+      public :exec_runtime
 
       def which(command)
         Array(command).find do |name|

--- a/lib/execjs/support/jsc_runner.js
+++ b/lib/execjs/support/jsc_runner.js
@@ -1,5 +1,5 @@
 (function(program, execJS) { execJS(program) })(function() {
-  return eval(#{encoded_source});
+  return eval(#{encode_source(source)});
 }, function(program) {
   var output;
   try {

--- a/lib/execjs/support/jscript_runner.js
+++ b/lib/execjs/support/jscript_runner.js
@@ -1,5 +1,5 @@
 (function(program, execJS) { execJS(program) })(function() {
-  return eval(#{encoded_source});
+  return eval(#{encode_source(source)});
 }, function(program) {
   #{json2_source}
   var output, print = function(string) {


### PR DESCRIPTION
Multiple `dup` and `sub` calls on the runner source template get costly. Since the template syntax we use is basically a lightweight ruby interpolation, lets just treat the runner source templates as big heredocs that are evaluated in the `ExternalRunner` instance.
