### PR TITLE
Fix #148 - Rubinius' IO.popen arg order

### DIFF
--- a/lib/execjs/external_runtime.rb
+++ b/lib/execjs/external_runtime.rb
@@ -142,7 +142,7 @@ module ExecJS
       end
 
       def exec_runtime(filename)
-        io = IO.popen(binary.split(' ') + [filename, {err: [:child, :out]}], @popen_options)
+        io = IO.popen(binary.split(' ') << filename, @popen_options.merge({err: [:child, :out]}))
         output = io.read
         io.close
 


### PR DESCRIPTION
This _should_ be fixed at rubinius/rubinius#3060 since the Ruby spec allows both forms, but this fixes the problem for now.
