### PR TITLE
Correctly load runtime from environment

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -58,7 +58,7 @@ module ExecJS
 
     def self.from_environment
       if name = ENV["EXECJS_RUNTIME"]
-        if runtime = const_get(name)
+        if runtime = const_get(name).new
           if runtime.available?
             runtime if runtime.available?
           else


### PR DESCRIPTION
As an aside, I'm using a gem (activeadmin) that loads the coffee-script gem which requires execjs. I don't compile assets in production. So, when the execjs gem loads in production, there's no js runtime available and I get a failure.

StackOverflow is filled with people asking this, and the common suggestion is "install nodejs", even though there's no reason for it, other than execjs failing to load.

Is my only option to set `EXECJS_RUNTIME=ExecJS::DisabledRuntime`?
