### PR TITLE
use constants in runtimes for listing

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -75,16 +75,7 @@ module ExecJS
     end
 
     def self.runtimes
-      @runtimes ||= [
-        RubyRacer,
-        RubyRhino,
-        Johnson,
-        Mustang,
-        Node,
-        JavaScriptCore,
-        SpiderMonkey,
-        JScript
-      ]
+      @runtimes ||= constants.map { |const| const_get(const) }
     end
   end
 


### PR DESCRIPTION
`ExecJS::Runtimes.runtimes` list all Runtimes explicit, `.name` read them form `.constants`, `.runtimes` should do the same.
