### PR TITLE
Allows NODE_RUNTIME to give path to node runtime

### DIFF
--- a/lib/execjs/runtimes.rb
+++ b/lib/execjs/runtimes.rb
@@ -20,7 +20,7 @@ module ExecJS
 
     Node = ExternalRuntime.new(
       name:        "Node.js (V8)",
-      command:     ["nodejs", "node"],
+      command:     [ENV.fetch('NODEJS_RUNTIME', "nodejs"), "node"],
       runner_path: ExecJS.root + "/support/node_runner.js",
       encoding:    'UTF-8'
     )


### PR DESCRIPTION
Accepts an Environment Variable "NODEJS_RUNTIME" containing the path
to the node command on systems with alternate directory structures.

```
NODEJS_RUNTIME=/usr/local/bin/node
```

The variable is not required, and ExecJS will look for the executable
names in the PATH.

Under FreeBSD, Passenger + Rails fails to load the node runtime, even
though it is installed at /usr/local/bin/node, and control of the PATH
variable is not available.
