### PR TITLE
Simplify JSC encode

### DIFF
--- a/lib/execjs/support/jsc_runner.js
+++ b/lib/execjs/support/jsc_runner.js
@@ -1,5 +1,4 @@
-(function(program, execJS) { execJS(program) })(function() {
-  return eval(#{encode_source(source)});
+(function(program, execJS) { execJS(program) })(function() { #{source}
 }, function(program) {
   var output;
   try {


### PR DESCRIPTION
Shouldn't need this extra encode step for JSC anymore. Should give better backtraces.
