### PR TITLE
For large amounts of coffee script files running on 1.9.3 we see strange issues

### DIFF
--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -55,7 +55,15 @@ module ExecJS
             if e.value["name"] == "SyntaxError"
               raise RuntimeError, e.value.to_s
             else
-              raise ProgramError, e.value.to_s
+              # If there are alot of files there may be issues with over run / memory management 
+              # lets retry after a 20 second sleep to allow the system to catch up
+              # and retry one more time
+              begin
+                sleep(20)
+                unbox @v8_context.eval(properties).call(*args)
+              rescue ::V8::JSError => e
+                raise ProgramError, e.value.to_s
+              end
             end
           end
         end

--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -65,6 +65,16 @@ module ExecJS
                 raise ProgramError, e.value.to_s
               end
             end
+          rescue Exception => e
+            # If there are alot of files there may be issues with over run / memory management 
+            # lets retry after a 20 second sleep to allow the system to catch up
+            # and retry one more time
+            begin
+              sleep(20)
+              unbox @v8_context.eval(properties).call(*args)
+            rescue Exception => e
+              raise e
+            end            
           end
         end
       end

--- a/lib/execjs/version.rb
+++ b/lib/execjs/version.rb
@@ -1,3 +1,3 @@
 module ExecJS
-  VERSION = "2.3.0"
+  VERSION = "2.3.0.2"
 end


### PR DESCRIPTION
Hi there,
We are running 1.9.3 and rails 3.2.21. We have ALOT of coffeescript files and we are seeing very strange errors coming out when the coffeescript is valid (when we compile on 2.1.5 we have no problems). When debugging, if I let the system sleep for 5 - 10 seconds all would be well.  My thoughts are around a V8 memory issue where a pause allows clean up / synching. 

Best Regards,
Brendan

The args below when passed to 'unbox @v8_context.eval(properties).call' would cause a compiler error but pass when we wait for 10 seconds:

["App.i18n = new Jed\n  locale_data:\n\n    domain: \"messages\"\n\n    # messages (translation strings) will be requested from the server for the specified lang using AJAX (for full site i18n)\n    messages:\n      \"\":\n        domain: \"messages\"\n        lang: \"en\"\n        plural_forms : \"nplurals=2; plural=(n != 1);\"\n\n    # latino_messages is used by the latino page, even when a different language is set for the user\n    latino_messages:\n      \"\":\n        domain: \"latino_messages\"\n        lang: \"es\"\n        plural_forms : \"nplurals=2; plural=(n != 1);\"\n\n      # Homepage\n      \"Movies\"              : [ null, \"Películas\"]\n      \"Shows\"               : [ null, \"Programas\"]\n      \"View All\"            : [ null, \"Mostrar más\"]\n      \"Latino Networks\"     : [ null, \"Cadenas nacionales\"]\n\n      # Navbar\n      \"Navigation\"          : [ null, \"Menú\"]\n      \"HOME\"                : [ null, \"Casa\"]\n      \"SHOWS\"               : [ null, \"Programas\"]\n      \"MOVIES\"              : [ null, \"Películas\"]\n      \"Sports\"              : [ null, \"Deportes\"]\n      \"Guide\"               : [ null, \"Guía\"]\n      \"My DVR\"              : [ null, \"Mi DVR\"]\n      \"Live TV\"             : [ null, \"TV Vivo\"]\n      \"Watchlist\"           : [ null, \"Mi Lista\"]\n\n      \"Featured Shows\"      : [ null, \"Programas Destacados\"]\n      \"All Shows\"           : [ null, \"Todos los Programas\"]\n      \"Networks\"            : [ null, \"Las Redes\"]\n\n      \"Featured Movies\"     : [ null, \"Películas Destacados\"]\n      \"All Movies\"          : [ null, \"Todos los Películas\"]\n      \"My Recordings\"       : [ null, \"Mis Grabaciones\"]\n      \"Daily Schedule\"      : [ null, \"Programación Diaria\"]\n      \"My Timers\"           : [ null, \"Mis Temporizadores\"]\n\n      # Subnav\n      \"Kids\"                : [ null, \"Niños\"]\n      \"Showcase\"            : [ null, \"Mostrar\"]\n\n      # Account Navbar\n      \"Login\"               : [ null, \"Entrar\"]\n      \"Log Out\"             : [ null, \"Salir\"]\n      \"Account\"             : [ null, \"Cuenta\"]\n      \"Account and Devices\" : [ null, \"Mi Cuenta\"]\n      \"Manage Profiles\"     : [ null, \"Administrar Usuarios\"]\n      \"Parental Controls\"   : [ null, \"Controles Parentales\"]\n      \"Enable Kids Mode\"    : [ null, \"Activar el Modo de Niños\"]\n      \"Help\"                : [ null, \"Ayuda\"]\n      \"Recents\"             : [ null, \"Recientes\"]\n\n      # Carousels\n      \"Refresh network\"     : [\"Refresh to validate network subscription\",\n                              \"Actualiza para validar suscripción a la red\"\n                              ]\n\n\n# translation helper function\nApp.i18n.t = (string, vars...) ->\n  @translate(string).fetch(vars...)\n\n# Manages the correct translation domain based on the route\nApp.i18n.setDomain = (route) ->\n  if route.match(\"^latino\") then @textdomain \"latino_messages\" else @textdomain \"messages\"\n", {:bare=>false}]

For large amounts of coffee script files running on 1.9.3 we see strange issues where a file will error on the call when it is a perfectly good coffeescript file. As a result I am adding a second retry to allow the system to recover. Unfortunately, I could not dig deep enough to find out what the issue is. There does not seem to be a good way to see the internals when the script is sent to V8
