### PR TITLE
Add Rubinius to Build Matrix with Allowed Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,8 @@ rvm:
   - 2.1
   - 2.2
   - jruby-19mode
+  - rbx-2
+  
+matrix:
+  allow_failures:
+    - rvm: rbx-2


### PR DESCRIPTION
Adding Rubinius to build matrix to verify that ExecJS work on Rubinius. I would appreciate if you could add this to your build matrix so we can ensure ExecJS works on Rubinius. Thank you.
