### PR TITLE
Opt in to new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
   - 1.9.3


### PR DESCRIPTION
The builds should finish way faster on Travis new Docker-based infrastructure.

Right now a bunch of execjs builds on old infrastucture are backed up for almost a day now due to some recent availability issues on Travis platform. (If anyone with write access to execjs is reading this, you might want to try to cancel those jobs to free up the queue for newer jobs.) This wouldn't happen on Docker.