### PR TITLE
Return a backtrace where possible

### DIFF
--- a/lib/execjs/module.rb
+++ b/lib/execjs/module.rb
@@ -2,7 +2,15 @@ require "execjs/version"
 require "rbconfig"
 
 module ExecJS
-  class Error           < ::StandardError; end
+  class Error < ::StandardError
+    attr_reader :backtrace
+
+    def initialize(message, backtrace = nil)
+      super(message)
+      @backtrace = backtrace
+    end
+  end
+
   class RuntimeError              < Error; end
   class ProgramError              < Error; end
   class RuntimeUnavailable < RuntimeError; end

--- a/lib/execjs/ruby_racer_runtime.rb
+++ b/lib/execjs/ruby_racer_runtime.rb
@@ -13,9 +13,9 @@ module ExecJS
             @v8_context.eval(source)
           rescue ::V8::JSError => e
             if e.value["name"] == "SyntaxError"
-              raise RuntimeError, e.value.to_s
+              raise RuntimeError.new(e.value.to_s, e.backtrace)
             else
-              raise ProgramError, e.value.to_s
+              raise ProgramError.new(e.value.to_s, e.backtrace)
             end
           end
         end
@@ -38,9 +38,9 @@ module ExecJS
               unbox @v8_context.eval("(#{source})")
             rescue ::V8::JSError => e
               if e.value["name"] == "SyntaxError"
-                raise RuntimeError, e.value.to_s
+                raise RuntimeError.new(e.value.to_s, e.backtrace)
               else
-                raise ProgramError, e.value.to_s
+                raise ProgramError.new(e.value.to_s, e.backtrace)
               end
             end
           end
@@ -53,9 +53,9 @@ module ExecJS
             unbox @v8_context.eval(properties).call(*args)
           rescue ::V8::JSError => e
             if e.value["name"] == "SyntaxError"
-              raise RuntimeError, e.value.to_s
+              raise RuntimeError.new(e.value.to_s, e.backtrace)
             else
-              raise ProgramError, e.value.to_s
+              raise ProgramError.new(e.value.to_s, e.backtrace)
             end
           end
         end


### PR DESCRIPTION
To help with debugging, it seemed to make sense to keep the V8 backtrace rather than throwing it away